### PR TITLE
Add command environment variables config

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ build_delay: 200ms
 binary_name: refresh-build
 # any extra commands you want to send to the built binary when it is run:
 command_flags: []
+# any extra environment variables you want to send to the built binary when it is run:
+command_env: []
 # do you want to use colors when printing out log messages:
 enable_colors: true
 ```

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -23,6 +23,7 @@ var initCmd = &cobra.Command{
 			BuildDelay:         200,
 			BinaryName:         "refresh-build",
 			CommandFlags:       []string{},
+			CommandEnv:         []string{},
 			EnableColors:       true,
 		}
 		c.Dump(cfgFile)

--- a/refresh.yml
+++ b/refresh.yml
@@ -9,4 +9,5 @@ build_path: /tmp
 build_delay: 200ns
 binary_name: refresh-build
 command_flags: []
+command_env: []
 enable_colors: true

--- a/refresh/config.go
+++ b/refresh/config.go
@@ -21,6 +21,7 @@ type Configuration struct {
 	BuildDelay         time.Duration `yaml:"build_delay"`
 	BinaryName         string        `yaml:"binary_name"`
 	CommandFlags       []string      `yaml:"command_flags"`
+	CommandEnv         []string      `yaml:"command_env"`
 	EnableColors       bool          `yaml:"enable_colors"`
 	LogName            string        `yaml:"log_name"`
 }

--- a/refresh/runner.go
+++ b/refresh/runner.go
@@ -36,6 +36,11 @@ func (m *Manager) runAndListen(cmd *exec.Cmd) error {
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 
+	// Set the environment variables from config
+	if len(m.CommandEnv) != 0 {
+		cmd.Env = append(m.CommandEnv, os.Environ()...)
+	}
+
 	err := cmd.Start()
 	if err != nil {
 		return fmt.Errorf("%s\n%s", err, stderr.String())


### PR DESCRIPTION
I needed the ability to pass through environment variables to refresh, and noticed it was missing from the configuration (there's only command flags at the moment), so I've added it in this PR. Thanks.