### PR TITLE
Allow users to specify a build target directory - useful if for examp…

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -19,6 +19,7 @@ var initCmd = &cobra.Command{
 			AppRoot:            ".",
 			IgnoredFolders:     []string{"vendor", "log", "logs", "tmp", "node_modules", "bin", "templates"},
 			IncludedExtensions: []string{".go"},
+			BuildTargetPath:    "",
 			BuildPath:          os.TempDir(),
 			BuildDelay:         200,
 			BinaryName:         "refresh-build",

--- a/refresh/config.go
+++ b/refresh/config.go
@@ -17,6 +17,7 @@ type Configuration struct {
 	AppRoot            string        `yaml:"app_root"`
 	IgnoredFolders     []string      `yaml:"ignored_folders"`
 	IncludedExtensions []string      `yaml:"included_extensions"`
+	BuildTargetPath    string        `yaml:"build_target_path"`
 	BuildPath          string        `yaml:"build_path"`
 	BuildDelay         time.Duration `yaml:"build_delay"`
 	BinaryName         string        `yaml:"binary_name"`

--- a/refresh/manager.go
+++ b/refresh/manager.go
@@ -83,7 +83,7 @@ func (r *Manager) build(event fsnotify.Event) {
 
 			now := time.Now()
 			r.Logger.Print("Rebuild on: %s", event.Name)
-			cmd := exec.Command("go", "build", "-v", "-i", "-o", r.FullBuildPath())
+			cmd := exec.Command("go", "build", "-v", "-i", "-o", r.FullBuildPath(), r.Configuration.BuildTargetPath)
 			err := r.runAndListen(cmd)
 			if err != nil {
 				if strings.Contains(err.Error(), "no buildable Go source files") {


### PR DESCRIPTION
This small changes allows users to specify a build target path. I find this useful in cases where my project has many modules and I'd like to be able to specify the path of say a REST service to be rebuild and run. 