### PR TITLE
set build_flags: [-v, -i] if empty for compatibility, small updates to doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Once you have your configuration all set up, all you need to do is run it:
 
 ```
 $ refresh run
+or
+$ refresh
 ```
 
 That's it! Now, as you change your code the binary will be re-built and re-started for you.
@@ -60,18 +62,24 @@ app_root: .
 ignored_folders:
   - vendor
   - log
+  - logs
   - tmp
+  - node_modules
+  - bin
+  - templates
 # a list of file extensions you want to watch for changes:
 included_extensions:
   - .go
+# If you have a specific sub-directory of your project you want to build
+build_target_path: ""
 # the directory you want to build your binary in:
 build_path: /tmp
 # `fsnotify` can trigger many events at once when you change a file.
 # in order to help cut down on the amount of builds that occur, a delay
 # is used to let the extra events fly away.
 build_delay: 200ms
-# If you have a specific sub-directory of your project you want to build
-build_target_path : ""
+# If you want to add flags to go build ([-v, -i] if empty for compatibility)
+build_flags: [-v, -i, -race]
 # what would you like to call the built binary:
 binary_name: refresh-build
 # any extra commands you want to send to the built binary when it is run:
@@ -80,4 +88,6 @@ command_flags: []
 command_env: []
 # do you want to use colors when printing out log messages:
 enable_colors: true
+# if you want to change the LogName (default to `refresh`)
+log_name: ""
 ```

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -22,6 +22,7 @@ var initCmd = &cobra.Command{
 			BuildTargetPath:    "",
 			BuildPath:          os.TempDir(),
 			BuildDelay:         200,
+			BuildFlags:         []string{"-v", "-i", "-race"},
 			BinaryName:         "refresh-build",
 			CommandFlags:       []string{},
 			CommandEnv:         []string{},

--- a/refresh.yml
+++ b/refresh.yml
@@ -2,12 +2,19 @@ app_root: .
 ignored_folders:
 - vendor
 - log
+- logs
 - tmp
+- node_modules
+- bin
+- templates
 included_extensions:
 - .go
+build_target_path: ""
 build_path: /tmp
 build_delay: 200ns
+build_flags: [-v, -i, -race]
 binary_name: refresh-build
 command_flags: []
 command_env: []
 enable_colors: true
+log_name: ""

--- a/refresh/config.go
+++ b/refresh/config.go
@@ -20,6 +20,7 @@ type Configuration struct {
 	BuildTargetPath    string        `yaml:"build_target_path"`
 	BuildPath          string        `yaml:"build_path"`
 	BuildDelay         time.Duration `yaml:"build_delay"`
+	BuildFlags         []string      `yaml:"build_flags,flow"`
 	BinaryName         string        `yaml:"binary_name"`
 	CommandFlags       []string      `yaml:"command_flags"`
 	CommandEnv         []string      `yaml:"command_env"`
@@ -42,7 +43,16 @@ func (c *Configuration) Load(path string) error {
 	if err != nil {
 		return err
 	}
-	return yaml.Unmarshal(data, c)
+	err = yaml.Unmarshal(data, c)
+	if err != nil {
+		return err
+	}
+	// when build_flags is empty set to [-v, -i]
+	// for compatibility with previous versions
+	if len(c.BuildFlags) == 0 {
+		c.BuildFlags = []string{"-v", "-i"}
+	}
+	return nil
 }
 
 func (c *Configuration) Dump(path string) error {

--- a/refresh/manager.go
+++ b/refresh/manager.go
@@ -95,7 +95,11 @@ func (r *Manager) build(events []fsnotify.Event) {
 
 			now := time.Now()
 			r.Logger.Print("Rebuild on: %s", strings.Join(eventNames, ", "))
-			cmd := exec.Command("go", "build", "-v", "-i", "-o", r.FullBuildPath(), r.Configuration.BuildTargetPath)
+			args := []string{"build"}
+			args = append(args, r.BuildFlags...)
+			args = append(args, "-o", r.FullBuildPath())
+			args = append(args, r.Configuration.BuildTargetPath)
+			cmd := exec.Command("go", args...)
 			err := r.runAndListen(cmd)
 			if err != nil {
 				if strings.Contains(err.Error(), "no buildable Go source files") {


### PR DESCRIPTION
I didn't know how to differentiate between empty `build_flags:[]` and not set at all.
I updated the refresh.yml of the readme with the current init.