### PR TITLE
Add config parameter 'debug_flags' to specify the flags passed to delve.

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -25,6 +25,7 @@ var initCmd = &cobra.Command{
 			BinaryName:         "refresh-build",
 			CommandFlags:       []string{},
 			CommandEnv:         []string{},
+			DebugFlags:         []string{},
 			EnableColors:       true,
 		}
 		c.Dump(cfgFile)

--- a/refresh/config.go
+++ b/refresh/config.go
@@ -27,6 +27,7 @@ type Configuration struct {
 	EnableColors       bool          `yaml:"enable_colors"`
 	LogName            string        `yaml:"log_name"`
 	Debug              bool          `yaml:"-"`
+	DebugFlags         []string      `yaml:"debug_flags"`
 }
 
 func (c *Configuration) FullBuildPath() string {

--- a/refresh/runner.go
+++ b/refresh/runner.go
@@ -21,7 +21,9 @@ func (m *Manager) runner() {
 		}
 		if m.Debug {
 			bp := m.FullBuildPath()
-			args := []string{"exec", bp}
+			var args []string
+			args = append(args, m.DebugFlags...)
+			args = append(args, []string{"exec", bp}...)
 			args = append(args, m.CommandFlags...)
 			cmd = exec.Command("dlv", args...)
 		} else {


### PR DESCRIPTION
Mark,

Whilst trying to setup GoLand debugging, it seemed there wasn't an easy way to specify the arguments to pass to delve to setup the debugging port etc.

This PR adds that parameter, and enables `buffalo dev --debug` to easily be connected for debugging in the IDE. Requires a small template change in buffalo to make the feature obvious, for which I'll submit a separate merge request.

Best wishes,

Alex 