### PR TITLE
Skip -i flag in go build if modules are enabled

### DIFF
--- a/refresh/manager.go
+++ b/refresh/manager.go
@@ -13,6 +13,7 @@ import (
 	"github.com/fsnotify/fsnotify"
 	"github.com/gobuffalo/envy"
 	"github.com/gobuffalo/events"
+	"github.com/gobuffalo/genny/movinglater/gotools/gomods"
 )
 
 type Manager struct {
@@ -93,7 +94,10 @@ func (r *Manager) build(event fsnotify.Event) {
 			now := time.Now()
 			r.Logger.Print("Rebuild on: %s", event.Name)
 
-			args := []string{"build", "-v", "-i"}
+			args := []string{"build", "-v"}
+			if !gomods.On() {
+				args = append(args, "-i")
+			}
 			args = append(args, r.BuildFlags...)
 			args = append(args, "-o", r.FullBuildPath(), r.BuildTargetPath)
 			cmd := exec.Command(envy.Get("GO_BIN", "go"), args...)


### PR DESCRIPTION
Using -i flag when running go build is not useful with go modules enabled
and in some cases can lead to a bug, with go trying to rebuild
shipped vendorized dependencies as described in this issue
https://github.com/golang/go/issues/27285.
With this commit we check if go modules are enabled and we drop the -i
flag accordingly.