### PR TITLE
Allow the default refresh.yml file to exist in multiple locations

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -30,5 +30,5 @@ func Execute() {
 
 func init() {
 	RootCmd.PersistentFlags().BoolVarP(&debug, "debug", "d", false, "use delve to debug the app")
-	RootCmd.PersistentFlags().StringVarP(&cfgFile, "config", "c", "refresh.yml", "path to configuration file")
+	RootCmd.PersistentFlags().StringVarP(&cfgFile, "config", "c", "", "path to configuration file")
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -2,12 +2,16 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"log"
 	"os"
 
 	"github.com/markbates/refresh/refresh"
 	"github.com/spf13/cobra"
 )
+
+// ErrConfigNotExist is returned when a configuration file cannot be found.
+var ErrConfigNotExist = errors.New("no config file was found")
 
 func init() {
 	RootCmd.AddCommand(runCmd)
@@ -29,19 +33,48 @@ func Run(cfgFile string) {
 
 func RunWithContext(cfgFile string, ctx context.Context) {
 	c := &refresh.Configuration{}
-	err := c.Load(cfgFile)
-	if err != nil {
-		log.Fatalln(err)
-		os.Exit(-1)
+
+	if err := loadConfig(c, cfgFile); err != nil {
+		if err != ErrConfigNotExist {
+			log.Fatalln(err)
+			os.Exit(-1)
+		} else {
+			log.Println("No configuration loaded, proceeding with defaults")
+		}
+	}
+
+	if len(c.Path) > 0 {
+		log.Printf("Configuration loaded from %s\n", c.Path)
 	}
 
 	if debug {
 		c.Debug = true
 	}
+
 	r := refresh.NewWithContext(c, ctx)
-	err = r.Start()
-	if err != nil {
+	if err := r.Start(); err != nil {
 		log.Fatalln(err)
 		os.Exit(-1)
 	}
+}
+
+func loadConfig(c *refresh.Configuration, path string) error {
+	if len(path) > 0 {
+		return c.Load(path)
+	}
+
+	for _, f := range [4]string{
+		".refresh.yml",
+		".refresh.yaml",
+		"refresh.yml",
+		"refresh.yaml",
+	} {
+		err := c.Load(f)
+		if err != nil && os.IsNotExist(err) {
+			continue
+		}
+		return err
+	}
+
+	return ErrConfigNotExist
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -38,9 +38,9 @@ func RunWithContext(cfgFile string, ctx context.Context) {
 		if err != ErrConfigNotExist {
 			log.Fatalln(err)
 			os.Exit(-1)
-		} else {
-			log.Println("No configuration loaded, proceeding with defaults")
 		}
+
+		log.Println("No configuration loaded, proceeding with defaults")
 	}
 
 	if len(c.Path) > 0 {

--- a/refresh/config.go
+++ b/refresh/config.go
@@ -27,6 +27,7 @@ type Configuration struct {
 	EnableColors       bool          `yaml:"enable_colors"`
 	LogName            string        `yaml:"log_name"`
 	Debug              bool          `yaml:"-"`
+	Path               string        `yaml:"-"`
 }
 
 func (c *Configuration) FullBuildPath() string {
@@ -44,6 +45,7 @@ func (c *Configuration) Load(path string) error {
 	if err != nil {
 		return err
 	}
+	c.Path = path
 	return yaml.Unmarshal(data, c)
 }
 


### PR DESCRIPTION
Rather than limit the configuration to just `refresh.yml`, this allows for developers to use their preferred yaml file extension, and allows for the dotfile prefix convention that is implemented by other tooling.

* When a `config, c` flag is explicitly set, only that file is looked for.
* Don't exit the run action if no configuration is found, the defaults are sane.
* Tell the configuration file that ends up being used.

There's also a few minor `err != nil` cleanups I added while I was in the file, nothing logic changing.

> __Unrelated note:__ I've opened a [PR for goreleaser/godownloader](https://github.com/goreleaser/godownloader/pull/99) so the project can benefit from a shell installer. Thought you'd like to know!