### PR TITLE
Add dot env files support

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -25,6 +25,7 @@ var initCmd = &cobra.Command{
 			BinaryName:         "refresh-build",
 			CommandFlags:       []string{},
 			CommandEnv:         []string{},
+			FileEnv:            "",
 			EnableColors:       true,
 		}
 		c.Dump(cfgFile)

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/fatih/color v1.7.0
 	github.com/fsnotify/fsnotify v1.4.7
 	github.com/gobuffalo/events v1.4.0
+	github.com/joho/godotenv v1.3.0
 	github.com/markbates/grift v1.5.0
 	github.com/mattn/go-colorable v0.1.4 // indirect
 	github.com/mattn/go-isatty v0.0.11 // indirect

--- a/go.sum
+++ b/go.sum
@@ -17,6 +17,8 @@ github.com/gobuffalo/here v0.4.0/go.mod h1:bTNk/uKZgycuB358iR0D32dI9kHBClBGpXjW2
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=
+github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=

--- a/refresh.yml
+++ b/refresh.yml
@@ -11,4 +11,5 @@ build_delay: 200ns
 binary_name: refresh-build
 command_flags: []
 command_env: []
+file_env: ""
 enable_colors: true

--- a/refresh/config.go
+++ b/refresh/config.go
@@ -24,6 +24,7 @@ type Configuration struct {
 	BinaryName         string        `yaml:"binary_name"`
 	CommandFlags       []string      `yaml:"command_flags"`
 	CommandEnv         []string      `yaml:"command_env"`
+	FileEnv            string        `yaml:"file_env"`
 	EnableColors       bool          `yaml:"enable_colors"`
 	LogName            string        `yaml:"log_name"`
 	ForcePolling       bool          `yaml:"force_polling,omitempty"`

--- a/refresh/runner.go
+++ b/refresh/runner.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+
+	"github.com/joho/godotenv"
 )
 
 func (m *Manager) runner() {
@@ -46,6 +48,14 @@ func (m *Manager) runAndListen(cmd *exec.Cmd) error {
 	// Set the environment variables from config
 	if len(m.CommandEnv) != 0 {
 		cmd.Env = append(m.CommandEnv, os.Environ()...)
+	}
+
+	// Load environment variables from a .env file
+	if m.FileEnv != "" {
+		err := godotenv.Load(m.FileEnv)
+		if err != nil {
+			return fmt.Errorf("%s\n%s", err, stderr.String())
+		}
 	}
 
 	err := cmd.Start()


### PR DESCRIPTION
This PR allows to load a custom `.env` file via [`github.com/joho/godotenv`](https://github.com/joho/godotenv) introducing a new `file_env` config entry (`FileEnv string`) which is empty by default meaning that refresh does not load any `.env` if it's not explicitly specified.

`refresh.yml` example:

```yml
# ....
command_env: []
file_env: "some_file.env"
enable_colors: true
# ....
```
