### PR TITLE
Send SIGTERM to give the process a chance to clean up

### DIFF
--- a/refresh/runner.go
+++ b/refresh/runner.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"syscall"
 )
 
 func (m *Manager) runner() {
@@ -17,7 +18,7 @@ func (m *Manager) runner() {
 			// kill the previous command
 			pid := cmd.Process.Pid
 			m.Logger.Success("Stopping: PID %d", pid)
-			cmd.Process.Kill()
+			cmd.Process.Signal(syscall.SIGTERM)
 		}
 		if m.Debug {
 			bp := m.FullBuildPath()


### PR DESCRIPTION
Killing the process doesn't let any defer handlers to be run. SIGTERM is a bit of a nicer approach, while still signalling the process it absolutely has to terminate, it gives a chance to clean up first.

With the most recent Go version, SIGINT should also work according to https://golang.org/pkg/os/signal/#hdr-Windows and it is also tested https://golang.org/src/os/signal/signal_windows_test.go.

Still, I propose to use SIGTERM, as it conveys the meaning better in this case, and is more portable (no extra code-paths on Windows).